### PR TITLE
Update InformixSchemaManager.php

### DIFF
--- a/lib/Doctrine/DBAL/Schema/InformixSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/InformixSchemaManager.php
@@ -221,11 +221,11 @@ class InformixSchemaManager extends AbstractSchemaManager
         foreach ( range(1, 16) as $i ) {
 
             if ( ! empty($tableForeignKey["col$i"]) ) {
-                $fkColnames[] = $tableForeignKey["col$i"];
+                $fkColnames[0] = $tableForeignKey["col$i"];
             }
 
             if ( ! empty($tableForeignKey["pkcol$i"]) ) {
-                $pkColnames[] = $tableForeignKey["pkcol$i"];
+                $pkColnames[0] = $tableForeignKey["pkcol$i"];
             }
 
         }


### PR DESCRIPTION
Without array key 0 I got an error on doctrine mapping import, the error says that property is duplicated.
